### PR TITLE
Add support for `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,5 +41,5 @@ all-features = true
 
 
 [features]
-default = ["nom", "std"]
+default = ["std"]
 std = ["dep:thiserror"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,22 @@ description = "Library to work with two-line element set files"
 authors = ["Federico Stra <stra.federico@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/FedericoStra/tletools-rs"
-categories = ["aerospace", "aerospace::space-protocols", "parser-implementations", "science"]
+categories = [
+    "aerospace",
+    "aerospace::space-protocols",
+    "parser-implementations",
+    "science",
+]
 keywords = ["tle"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nom = { version = "7.1.0", optional = true }
-thiserror = "1.0.30"
+nom = { version = "7.1.0", optional = true, default-features = false }
+thiserror = { version = "1.0.30", optional = true }
+num-traits = "0.2"
+cfg-if = "1.0"
 
 [dev-dependencies]
 criterion = "0.3.5"
@@ -31,3 +38,8 @@ harness = false
 [package.metadata.docs.rs]
 all-features = true
 # rustdoc-args = ["--cfg", "docsrs"]
+
+
+[features]
+default = ["nom", "std"]
+std = ["dep:thiserror"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 [dependencies]
 nom = { version = "7.1.0", optional = true, default-features = false }
 thiserror = { version = "1.0.30", optional = true }
-num-traits = "0.2"
+num-traits = { version = "0.2", default-features = false }
 cfg-if = "1.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@
 `TLE-tools` is a small library to work with [two-line element
 set](https://en.wikipedia.org/wiki/Two-line_element_set) files.
 
+## Features
+
+This crate can be used without the standard library (`#![no_std]`) by disabling
+the default `std` feature. Use this in `Cargo.toml`:
+
+```toml
+[dependencies]
+tletools = {version = "0.x.y", default-features = false} 
+```
+
 ## Purpose
 
 The purpose of the library is to parse TLE sets into convenient `TLE` structures.
@@ -47,3 +57,4 @@ Some more or less complete TLE format specifications can be found on the followi
 - Documentation: https://docs.rs/tletools
 - Releases: https://crates.io/crates/tletools
 - Issue tracker: https://github.com/FedericoStra/tletools-rs/issues
+

--- a/examples/read-all.rs
+++ b/examples/read-all.rs
@@ -1,9 +1,6 @@
+use itertools::Itertools;
 use std::fs;
 use std::io::{self, prelude::*, BufReader};
-
-use itertools::Itertools;
-
-use tletools;
 
 fn main() -> io::Result<()> {
     for date_folder in fs::read_dir("data")? {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(doc, feature(doc_auto_cfg))]
 
 //! **TLE-tools** is a small library to work with [`two-line element set`] files.
@@ -55,7 +56,19 @@ pub struct TLE {
 }
 
 mod implem;
+use cfg_if::cfg_if;
 pub use implem::*;
 
 #[cfg(feature = "nom")]
 pub mod nom;
+
+cfg_if! {
+    if #[cfg(feature = "std")]
+    {
+        extern crate std;
+    }else{
+        extern crate alloc;
+        use alloc::string::String;
+        extern crate core as std;
+    }
+}


### PR DESCRIPTION
## Description

This pull request modifies the TLE-tools crate to enable it to be used without the standard library .This change makes the library suitable for use in environments where the standard library is not available or is undesired, such as embedded systems .

## Testing Done

- Verified that the crate compiles successfully with the changes.
- Ensured that the functionality provided by TLE-tools remains intact and usable without the standard library.
- Tested the library in environments where the standard library is not available or disabled to confirm its compatibility and correctness.

## Request for Review

Please review these changes and provide any feedback or suggestions. Your input is valuable in ensuring the quality and effectiveness of this modification.
